### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cedar-policy/prism-cedar/security/code-scanning/1](https://github.com/cedar-policy/prism-cedar/security/code-scanning/1)

To fix this problem, you should explicitly add a `permissions:` key to the workflow or job to set the minimum required permissions for the GitHub Actions GITHUB_TOKEN. In this scenario, the workflow performs code checkout, installs dependencies, builds, tests, and checks for changes, but does not require any write permissions to repository contents or other resources. Therefore, setting `permissions: contents: read` at the workflow level provides the minimum privilege needed. The edit should be done by inserting a `permissions:` block after the `name` line (the top of the file, before `on:`). No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
